### PR TITLE
fixed the alignment issue of team members

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -237,7 +237,7 @@ canvas {
 
 .container {
 	display: flex;
-	align-items: flex-end;
+	align-items: stretch;
 	color: white;
 	width: 100%;
 	justify-content: center;
@@ -254,6 +254,9 @@ canvas {
 .podium__item {
 	width: 250px;
 	transition: 0.5s;
+	display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 85% 25%;
 }
 
 .podium__item:hover {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -259,6 +259,11 @@ canvas {
     grid-template-rows: 85% 25%;
 }
 
+.team__details{
+	margin-top: 15px;
+	text-align: center;
+}
+
 .podium__item:hover {
 	@media screen and (min-width: 768px) {
 		scale: 120%;
@@ -286,7 +291,7 @@ canvas {
 
 .podium .first {
 	height: 300px;
-
+	margin-top: -60px;
 	@media screen and (max-width: 400px) {
 		scale: 90%;
 	}

--- a/client/src/Components/EventsPodium.tsx
+++ b/client/src/Components/EventsPodium.tsx
@@ -104,8 +104,10 @@ export default function EventsPodium({ teams }: Prop) {
                                 (<></>)
                         }
                     </div>
-                    <p style={{ color: "white" }}>#2</p>
-                    <p style={{ color: "white" }}>{(secondTeam) ? secondTeam.name : ""}</p>
+                    <div className="team__details">
+                        <p style={{ color: "white" }}>#2</p>
+                        <p style={{ color: "white" }}>{(secondTeam) ? secondTeam.name : ""}</p>
+                    </div>
                 </div>
                 <div className='events-podium-container' style={{ display: "flex", flexDirection: "column" }}>
                     <div className="container-events-podium container podium">
@@ -185,8 +187,10 @@ export default function EventsPodium({ teams }: Prop) {
                                 (<></>)
                         }
                     </div>
-                    <p style={{ color: "white" }}>#1</p>
-                    <p style={{ color: "white" }}>{(firstTeam) ? firstTeam.name : ""}</p>
+                    <div className="team__details">
+                        <p style={{ color: "white" }}>#1</p>
+                        <p style={{ color: "white" }}>{(firstTeam) ? firstTeam.name : ""}</p>
+                    </div>
                 </div>
                 {
                     (thirdTeam) ?
@@ -269,8 +273,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             (<></>)
                                     }
                                 </div>
-                                <p style={{ color: "white" }}>#3</p>
-                                <p style={{ color: "white" }}>{thirdTeam.name}</p>
+                                <div className="team__details">
+                                    <p style={{ color: "white" }}>#3</p>
+                                    <p style={{ color: "white" }}>{thirdTeam.name}</p>
+                                </div>
                             </div>
                     ):
                     (<></>)

--- a/client/src/Components/EventsPodium.tsx
+++ b/client/src/Components/EventsPodium.tsx
@@ -44,8 +44,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#2</p> */}
-                                        <p className="podium__city">{secondTeam.members[1].name}</p>
-                                        <p className="podium__city">{secondTeam.members[1].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{secondTeam.members[1].name}</p>
+                                            <p className="podium__city">{secondTeam.members[1].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -67,8 +69,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#1</p> */}
-                                        <p className="podium__city">{secondTeam.members[0].name}</p>
-                                        <p className="podium__city">{secondTeam.members[0].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{secondTeam.members[0].name}</p>
+                                            <p className="podium__city">{secondTeam.members[0].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -90,8 +94,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#3</p> */}
-                                        <p className="podium__city">{secondTeam.members[2].name}</p>
-                                        <p className="podium__city">{secondTeam.members[2].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{secondTeam.members[2].name}</p>
+                                            <p className="podium__city">{secondTeam.members[2].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -119,8 +125,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#2</p> */}
-                                        <p className="podium__city">{firstTeam.members[1].name}</p>
-                                        <p className="podium__city">{firstTeam.members[1].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{firstTeam.members[1].name}</p>
+                                            <p className="podium__city">{firstTeam.members[1].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -142,8 +150,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#1</p> */}
-                                        <p className="podium__city">{firstTeam.members[0].name}</p>
-                                        <p className="podium__city">{firstTeam.members[0].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{firstTeam.members[0].name}</p>
+                                            <p className="podium__city">{firstTeam.members[0].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -165,8 +175,10 @@ export default function EventsPodium({ teams }: Prop) {
                                             </div>
                                         </div>
                                         {/* <p className="podium__city">#3</p> */}
-                                        <p className="podium__city">{firstTeam.members[2].name}</p>
-                                        <p className="podium__city">{firstTeam.members[2].reg_no}</p>
+                                        <div className="city__container">
+                                            <p className="podium__city">{firstTeam.members[2].name}</p>
+                                            <p className="podium__city">{firstTeam.members[2].reg_no}</p>
+                                        </div>
                                     </div>
                                 )
                                 :
@@ -197,8 +209,10 @@ export default function EventsPodium({ teams }: Prop) {
                                                         </div>
                                                     </div>
                                                     {/* <p className="podium__city">#2</p> */}
-                                                    <p className="podium__city">{thirdTeam.members[1].name}</p>
-                                                    <p className="podium__city">{thirdTeam.members[1].reg_no}</p>
+                                                    <div className="city__container">
+                                                        <p className="podium__city">{thirdTeam.members[1].name}</p>
+                                                        <p className="podium__city">{thirdTeam.members[1].reg_no}</p>
+                                                    </div>
                                                 </div>
                                             )
                                             :
@@ -220,8 +234,10 @@ export default function EventsPodium({ teams }: Prop) {
                                                         </div>
                                                     </div>
                                                     {/* <p className="podium__city">#1</p> */}
-                                                    <p className="podium__city">{thirdTeam.members[0].name}</p>
-                                                    <p className="podium__city">{thirdTeam.members[0].reg_no}</p>
+                                                    <div className="city__container">
+                                                        <p className="podium__city">{thirdTeam.members[0].name}</p>
+                                                        <p className="podium__city">{thirdTeam.members[0].reg_no}</p>
+                                                    </div>
                                                 </div>
                                             )
                                             :
@@ -243,8 +259,10 @@ export default function EventsPodium({ teams }: Prop) {
                                                         </div>
                                                     </div>
                                                     {/* <p className="podium__city">#3</p> */}
-                                                    <p className="podium__city">{thirdTeam.members[2].name}</p>
-                                                    <p className="podium__city">{thirdTeam.members[2].reg_no}</p>
+                                                    <div className="city__container">
+                                                        <p className="podium__city">{thirdTeam.members[2].name}</p>
+                                                        <p className="podium__city">{thirdTeam.members[2].reg_no}</p>
+                                                    </div>
                                                 </div>
                                             )
                                             :


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The alignment of the names of winners was not right. It was because the divs with `.podium-items` class were flex items because they are inside the `.container` div which is a flex container and had `align-items:flex-end;`. That's why the names were aligned to the end of the container. I fixed the issue by converting each `.podium-items` div into css grid of 2 rows and 1 column. Then changing the `align-items:` to `stretch` and setting relevant height did the job.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes # 1

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The change is required because it makes the leaderboard look cleaner and easier to read. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!-- Ignore if not relevant for you -->

I tried to increase the length of the name of a winner, and it was still aligning perfectly. Even in the mobile viewport the alignment is ok.
### Steps to reproduce:
- Open inspect tools and find the html part where the names of winners are written using select tool.
- Try to increase the length of any of the name.
- Try changing the viewport size.

## Screenshots (if appropriate):
![Untitled](https://github.com/user-attachments/assets/d303f039-0e0f-4102-be4b-6a68af3873d1)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


**Test Configuration**:
* Firmware version: 
* Hardware: 
* Toolchain: 
* SDK: 